### PR TITLE
feat(config): add monetization settings for sponsor ads pricing

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -51,9 +51,9 @@ settings:
     theme_selector_enabled: true
   monetization:
     sponsor_ads:
-      currency: IDR
-      weekly_price: 100
-      monthly_price: 300
+      currency: USD
+      weekly_price: 300
+      monthly_price: 1000
 logo:
   logo_image: /logo-light.png
   logo_image_dark: https://raw.githubusercontent.com/ever-works/awesome-time-tracking-data/master/pages/logo-dark.png

--- a/config.yml
+++ b/config.yml
@@ -49,6 +49,11 @@ settings:
     subscribe_enabled: true
     version_enabled: true
     theme_selector_enabled: true
+  monetization:
+    sponsor_ads:
+      currency: IDR
+      weekly_price: 100
+      monthly_price: 300
 logo:
   logo_image: /logo-light.png
   logo_image_dark: https://raw.githubusercontent.com/ever-works/awesome-time-tracking-data/master/pages/logo-dark.png


### PR DESCRIPTION
## Summary
  - Add `monetization.sponsor_ads` settings section to config.yml
  - Configurable options for sponsor ad pricing:
    - `currency`: Currency code for displaying prices (e.g., IDR, USD, EUR)
    - `weekly_price`: Price for weekly sponsorship
    - `monthly_price`: Price for monthly sponsorship

  ## Changes
  ```yaml
  settings:
    monetization:
      sponsor_ads:
        currency: IDR
        weekly_price: 100
        monthly_price: 300
```

  Related

  This config supports the admin sponsor ad pricing settings feature in the website template.